### PR TITLE
Handle extra deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 prefect>=2.0.0
+soda-core

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,15 @@ def get_extra_requires():
         "mysql",
         "postgres",
         "snowflake",
+        "trino",
     }
 
     # Generate extra requires for each db engine
     extra_requires = {db_engine: f"soda-core-{db_engine}" for db_engine in db_engines}
+
+    # Add specific deps for soda-core-spark
+    extra_requires["spark-hive"] = "soda-core-spark[hive]"
+    extra_requires["spark-odbc"] = "soda-core-spark[odbc]"
 
     # Add dev deps
     extra_requires["dev"] = dev_requires

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,31 @@ with open("requirements-dev.txt") as dev_requires_file:
 with open("README.md") as readme_file:
     readme = readme_file.read()
 
+
+def get_extra_requires():
+    # DB engines currently supported by Soda Core
+    # https://docs.soda.io/soda-core/installation.html#install
+    db_engines = {
+        "athena",
+        "redshift",
+        "spark-df",
+        "bigquery",
+        "db2",
+        "sqlserver",
+        "mysql",
+        "postgres",
+        "snowflake",
+    }
+
+    # Generate extra requires for each db engine
+    extra_requires = {db_engine: f"soda-core-{db_engine}" for db_engine in db_engines}
+
+    # Add dev deps
+    extra_requires["dev"] = install_requires
+
+    return extra_requires
+
+
 setup(
     name="prefect-soda-core",
     description="Prefect 2.0 collection for Soda Core",
@@ -26,7 +51,7 @@ setup(
     packages=find_packages(exclude=("tests", "docs")),
     python_requires=">=3.7",
     install_requires=install_requires,
-    extras_require={"dev": dev_requires},
+    extras_require=get_extra_requires(),
     classifiers=[
         "Natural Language :: English",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_extra_requires():
     extra_requires = {db_engine: f"soda-core-{db_engine}" for db_engine in db_engines}
 
     # Add dev deps
-    extra_requires["dev"] = install_requires
+    extra_requires["dev"] = dev_requires
 
     return extra_requires
 


### PR DESCRIPTION
## Summary
With this PR, the setup script will install the right `soda-core` package based on the user provided db engine that the user specifies as an optional dependency.

Examples:
`pip install prefect-soda-core[snowflake]` will install `soda-core-snowflake` and its dependencies.
`pip install prefect-soda-core` will install just `soda-core`.
