### PR TITLE
Add soda cloud credentials block

### DIFF
--- a/prefect_soda_core/soda_cloud_credentials.py
+++ b/prefect_soda_core/soda_cloud_credentials.py
@@ -1,0 +1,42 @@
+"""Soda Cloud credentials block"""
+from typing import Dict, Optional
+
+from prefect.blocks.core import Block
+from pydantic import HttpUrl, SecretStr
+from yaml import safe_dump
+
+
+class SodaCloudCredentials(Block):
+    """
+    This block can be used to manage authentication information
+    that are needed to authenticate with Soda Cloud.
+    """
+
+    host: Optional[str] = "cloud.soda.io"
+    api_key_id: SecretStr
+    api_key_secret: SecretStr
+
+    _block_type_name: Optional[str] = "Soda Cloud Credentials"
+    _logo_url: Optional[HttpUrl] = "https://www.TODO.todo"  # noqa
+
+    def get_block_as_json(self) -> Dict:
+        """
+        Returns the block JSON representation.
+        Returns:
+            JSON representation of the block.
+        """
+        return {
+            "soda_cloud": {
+                "host": self.host,
+                "api_key_id": self.api_key_id.get_secret_value(),
+                "api_key_secret": self.api_key_secret.get_secret_value(),
+            }
+        }
+
+    def get_block_as_yaml_str(self) -> str:
+        """
+        Returns the block YAML string representation.
+        Returns:
+            YAML string representation of the block.
+        """
+        return safe_dump(data=self.get_block_as_json())

--- a/tests/test_soda_cloud_credentials.py
+++ b/tests/test_soda_cloud_credentials.py
@@ -1,0 +1,57 @@
+from pydantic import SecretStr
+from yaml import dump
+
+from prefect_soda_core.soda_cloud_credentials import SodaCloudCredentials
+
+
+def test_credentials_construction():
+    api_key_id = "foo"
+    api_key_secret = "foo"
+
+    scc = SodaCloudCredentials(
+        api_key_id=SecretStr(api_key_id), api_key_secret=SecretStr(api_key_secret)
+    )
+
+    assert scc.api_key_id.get_secret_value() == api_key_id
+    assert scc.api_key_secret.get_secret_value() == api_key_secret
+    assert scc.host == "cloud.soda.io"
+
+
+def test_credentials_get_as_json():
+    api_key_id = "foo"
+    api_key_secret = "foo"
+
+    scc = SodaCloudCredentials(
+        api_key_id=SecretStr(api_key_id), api_key_secret=SecretStr(api_key_secret)
+    )
+
+    scc_as_json = scc.get_block_as_json()
+
+    assert scc_as_json == {
+        "soda_cloud": {
+            "host": "cloud.soda.io",
+            "api_key_id": api_key_id,
+            "api_key_secret": api_key_secret,
+        }
+    }
+
+
+def test_credentials_as_yaml():
+    api_key_id = "foo"
+    api_key_secret = "foo"
+
+    scc = SodaCloudCredentials(
+        api_key_id=SecretStr(api_key_id), api_key_secret=SecretStr(api_key_secret)
+    )
+
+    scc_as_yaml = scc.get_block_as_yaml_str()
+
+    scc_as_json = {
+        "soda_cloud": {
+            "host": "cloud.soda.io",
+            "api_key_id": api_key_id,
+            "api_key_secret": api_key_secret,
+        }
+    }
+
+    assert scc_as_yaml == dump(data=scc_as_json)


### PR DESCRIPTION
## Summary
This PR introduces a new `SodaCloudCredentials` block that will be used to handle Soda Cloud Credentials.