### PR TITLE
Add soda check block

### DIFF
--- a/prefect_soda_core/sodacl_check.py
+++ b/prefect_soda_core/sodacl_check.py
@@ -1,0 +1,16 @@
+"""SodaCL check block"""
+from typing import Optional, Union
+
+from prefect.blocks.core import Block
+from pydantic import DirectoryPath, FilePath, HttpUrl
+
+
+class SodaCLCheck(Block):
+    """
+    This block represents a SodaCL check that can be used when running Soda scans.
+    """
+
+    sodacl_yaml_files: Union[DirectoryPath, FilePath]
+
+    _block_type_name: Optional[str] = "SodaCL Check"
+    _logo_url: Optional[HttpUrl] = "https://www.to.do"  # noqa

--- a/prefect_soda_core/sodacl_check.py
+++ b/prefect_soda_core/sodacl_check.py
@@ -1,8 +1,8 @@
 """SodaCL check block"""
-from typing import Optional, Union
+from typing import Optional
 
 from prefect.blocks.core import Block
-from pydantic import DirectoryPath, FilePath, HttpUrl
+from pydantic import HttpUrl
 
 
 class SodaCLCheck(Block):
@@ -10,7 +10,7 @@ class SodaCLCheck(Block):
     This block represents a SodaCL check that can be used when running Soda scans.
     """
 
-    sodacl_yaml_files: Union[DirectoryPath, FilePath]
+    sodacl_yaml_files: str
 
     _block_type_name: Optional[str] = "SodaCL Check"
     _logo_url: Optional[HttpUrl] = "https://www.to.do"  # noqa

--- a/tests/test_sodacl_check.py
+++ b/tests/test_sodacl_check.py
@@ -1,0 +1,8 @@
+from prefect_soda_core.sodacl_check import SodaCLCheck
+
+
+def test_sodacl_check_construction():
+    soda_check_file_path = "/path/to/check_file.yaml"
+    scl = SodaCLCheck(sodacl_yaml_files=soda_check_file_path)
+
+    assert scl.sodacl_yaml_files == soda_check_file_path


### PR DESCRIPTION
## Summary
This PR introduces a `SodaCLCheck` block that can be used to manage checks written using Soda Check Language.
This block, together with the `SodaConfiguration` block, will be used as the main inputs of the `SodaScanExecute` task.