### PR TITLE
Removed Spark option and improved install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,18 @@ These tasks are designed to work with Prefect 2.0. For more information about ho
 
 ### Installation
 
-Install `prefect-soda-core` with `pip`:
+
+`prefect-soda-core` is based on `soda-core`.  
+As `soda-core` requires you to specify the right option for your database, so does `prefect-soda-core`.  
+I.e. to use `prefect-soda-core` with Snowflake, run the following:
 
 ```bash
-pip install prefect-soda-core
+pip install prefect-soda-core[snowflake]
 ```
+
+You can find the list of supported options in `setup.py`.
+
+**Please note that since this integration is built on top of Soda CLI, it is not possible to run data quality checks using Spark.**
 
 ### Write and run a flow
 

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ def get_extra_requires():
     # Generate extra requires for each db engine
     extra_requires = {db_engine: f"soda-core-{db_engine}" for db_engine in db_engines}
 
-    # Add specific deps for soda-core-spark
-    extra_requires["spark-hive"] = "soda-core-spark[hive]"
-    extra_requires["spark-odbc"] = "soda-core-spark[odbc]"
+    # Does not work with the current cli-based integration
+    # extra_requires["spark-hive"] = "soda-core-spark[hive]"
+    # extra_requires["spark-odbc"] = "soda-core-spark[odbc]"
 
     # Add dev deps
     extra_requires["dev"] = dev_requires


### PR DESCRIPTION
## Summary
- Removed Spark option since the integration is based on Soda CLI, which does not support running data quality checks using Spark.
- Improved install instructions