### PR TITLE
soda_scan_execute improvements: Accepting Environment Variables,  Dict-based scan results

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,5 +34,12 @@ Released on ????? ?th, 20??.
 
 ### Changed
 
-- `soda_scan_execute` task to accept `scan_results_file` as a param, allowing the soda scan results to be saved as JSON on the machine running it.
+The following changes have been made to `soda_scan_execute`:
+- Introducing the optional `return_scan_result_file_content` flag which if it's set to `True` will return the scan result file content as a dictionary. This is useful when you want to use the scan result file content in a downstream task, to send alerts independednt of soda-cloud for example.
+- Introducing the optional `scan_results_file` parameter which if it's set to a path, will save the scan result file to the specified path. This is useful when you want to save the scan result file to a specific location on the machine running the task. If `return_scan_result_file_content` is set to `True` but no `scan_results_file` is specified, the scan result file will be saved to the current working directory using the task run name and timestamp as the file name.
+- Introducing the optional `env_vars` parameter which if it's set to a dictionary, will pass the dictionary as environment variables to the shell task running the soda scan command. This is useful when you want to pass database credentials to the soda scan task. For example, if you want to scan a snowflake database, [you can pass the snowflake credentials such as account and password as environment variables to the soda scan task](https://docs.soda.io/soda/connect-snowflake.html#configuration). 
+
+### Fixed
+- In the `soda_scan_execute` task, handling the `RuntimeError` exception that is raised when the check runs successfully but does not pass, causing the flow running it to fail. This is the only way to handle this exception when the soda_scan_execute in a [mapped](https://docs.prefect.io/api-ref/prefect/tasks/#prefect.tasks.Task.map) mode.
+
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,13 @@ Released on ????? ?th, 20??.
 ### Added
 
 - `task_name` task - [#1](https://github.com/sodadata/prefect-soda-core/pull/1)
+
+
+## 0.1.1
+
+Released on ????? ?th, 20??.
+
+### Changed
+
+- `soda_scan_execute` task to accept `scan_results_file` as a param, allowing the soda scan results to be saved as JSON on the machine running it.
+

--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ def run_soda_scan():
         sodacl_yaml_path="/path/to/checks.yaml"
     )
     
+    # Using the flow_run_name as the name of the file to store the scan results
+    flow_run_name = get_run_context().flow_run.name
+    scan_results_file_path = f"{flow_run_name}.json"
+    
     return soda_scan_execute(
         data_source_name="my_datasource",
         configuration=soda_configuration_block,
         checks=soda_check_block,
         variables={"var": "value"},
+        scan_results_file=scan_results_file_path,
         verbose=True
     )
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ def run_soda_scan():
         variables={"var": "value"},
         scan_results_file=scan_results_file_path,
         verbose=True
+        return_scan_result_file_content=False,
+        shell_env={"SNOWFLAKE_PASSWORD": "********"}
     )
 
 run_soda_scan()

--- a/prefect_soda_core/tasks.py
+++ b/prefect_soda_core/tasks.py
@@ -17,6 +17,7 @@ async def soda_scan_execute(
     configuration: SodaConfiguration,
     checks: SodaCLCheck,
     variables: Optional[Dict[str, str]],
+    scan_results_file: Optional[str] = None,
     verbose: bool = False,
 ) -> Union[List, str]:
     """
@@ -36,6 +37,10 @@ async def soda_scan_execute(
             `configuration`, to configure the scan before its execution.
         variables: A `Dict[str, str]` that contains all variables
             references within checks.
+        scan_results_file: The path to the file where the scan results
+            will be stored. If not provided, the scan results will not
+            be stored on the file system and only the stdout of the soda
+            shell task would be returned.
         verbose: Whether to run the checks with a verbose log or not.
             Default to `False`.
 
@@ -64,7 +69,8 @@ async def soda_scan_execute(
                 configuration=soda_configuration_block,
                 checks=sodacl_check_block,
                 variables={"key": "value"},
-                verbose=False
+                scan_results_file="scan_output.json",
+                verbose=False,
             )
         ```
     """
@@ -89,6 +95,10 @@ async def soda_scan_execute(
         )
 
         command = f"{command} {var_str}"
+
+    # If scan results file is provided, add the to Soda command
+    if scan_results_file:
+        command = f"{command} -srf {scan_results_file}"
 
     # If verbose logging is requested, add corresponding option to Soda command
     if verbose:

--- a/prefect_soda_core/tasks.py
+++ b/prefect_soda_core/tasks.py
@@ -2,10 +2,12 @@
 Collection of tasks that can be used to run Data Quality checks
 using Soda Core.
 """
+import json
 from typing import Dict, List, Optional, Union
 
 from prefect import get_run_logger, task
 from prefect_shell import shell_run_command
+from prefect.context import get_run_context
 
 from prefect_soda_core.soda_configuration import SodaConfiguration
 from prefect_soda_core.sodacl_check import SodaCLCheck
@@ -19,6 +21,8 @@ async def soda_scan_execute(
     variables: Optional[Dict[str, str]],
     scan_results_file: Optional[str] = None,
     verbose: bool = False,
+    return_scan_result_file_content: bool = False,
+    shell_env: Optional[Dict[str, str]] = None,
 ) -> Union[List, str]:
     """
     Task that execute a Soda Scan.
@@ -43,6 +47,12 @@ async def soda_scan_execute(
             shell task would be returned.
         verbose: Whether to run the checks with a verbose log or not.
             Default to `False`.
+        return_scan_result_file_content: Controls the return of the task.
+            If `True`, the task will return the content of the scan results,
+            otherwise it will return the stdout of the soda shell task.
+            Default to `False`.
+        shell_env: A `Dict[str, str]` that contains all environment variables
+            that will be passed to the soda shell task.
 
     Raises:
         `RuntimeError` in case `soda scan` encounters any error
@@ -69,8 +79,10 @@ async def soda_scan_execute(
                 configuration=soda_configuration_block,
                 checks=sodacl_check_block,
                 variables={"key": "value"},
-                scan_results_file="scan_output.json",
+                scan_results_file="scan_results.json",
                 verbose=False,
+                return_scan_result_file_content=False,
+                shell_env={"SNOWFLAKE_PASSWORD": "********"}
             )
         ```
     """
@@ -96,8 +108,14 @@ async def soda_scan_execute(
 
         command = f"{command} {var_str}"
 
-    # If scan results file is provided, add the to Soda command
-    if scan_results_file:
+    # If return_scan_result_file_content is True, save the output of the scan to a file
+    if return_scan_result_file_content is True:
+        # Implicitly use task run name and time to store the JSON-based scan results file
+        if scan_results_file is None:
+            task_run_name = get_run_context().task_run.name
+            task_run_start_time = get_run_context().task_run.start_time
+            scan_results_file = f"{task_run_start_time}--{task_run_name}.json"
+
         command = f"{command} -srf {scan_results_file}"
 
     # If verbose logging is requested, add corresponding option to Soda command
@@ -111,6 +129,18 @@ async def soda_scan_execute(
     get_run_logger().debug(f"Soda requested command is: {command}")
 
     # Execute Soda command
-    soda_logs = await shell_run_command.fn(command=command, return_all=True)
+    try:
+        soda_logs = await shell_run_command.fn(
+            command=command, env=shell_env, return_all=True
+        )
+    except RuntimeError as e:
+        # Ignoring the Runtime Error with code 2 that is raised
+        #   when the soda test runs successfully but the check fails causing the flow to break.
+        if not str(e).startswith("Command failed with exit code 2:"):
+            raise e
+
+    if return_scan_result_file_content is True:
+        with open(scan_results_file, "r") as f:
+            soda_logs = json.load(f)
 
     return soda_logs


### PR DESCRIPTION
Updating the  `soda_scan_execute` task with options to pass environmental variables to the shell task running the Soda command and to save and return the dictionary-based scan results.

<!-- Thanks for contributing to prefect-soda-core! 🎉-->

## Summary
<!-- A brief summary explaining the purpose of this PR -->
As discussed at https://github.com/sodadata/prefect-soda-core/issues/16, this PR :
- Gives the user the option to receive more detailed scan results of the soda scan tasks.
- The same option, would result in the same scan results being saved on the disk. The user can (but does not have to) pass a custom path to store the JSON file.
- Gives the user the option to pass environment variables to be passed to the shell task. This could be helpful to [pass database credentials to the task](https://docs.soda.io/soda/connect-snowflake.html#configuration). In my flow, I retrieve a standard snowflake-credential block, build a dictionary of database credentials and pass it to this task.
- Handles the RuntimeError exception that is raised when the check runs successfully but does not pass. It is not the cleanest way to handle this but in my tests, this was the only way to handle this exception when the `soda_scan_execute` using [`map`](https://docs.prefect.io/api-ref/prefect/tasks/#prefect.tasks.Task.map).  However, I'm open to suggestions if you have a better way of handling this issue.

## Relevant Issue(s)
<!-- If this PR addresses any open issues, please let us know which one here -->
https://github.com/sodadata/prefect-soda-core/issues/16

## Checklist
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/sodadata/prefect-soda-core/blob/main/CHANGELOG.md)
