### PR TITLE
Fixed README example and pinned pydantic<2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You can find the list of supported options in `setup.py`.
 
 ```python
 from prefect import flow
+from prefect.context import get_run_context
 from prefect_soda_core.soda_configuration import SodaConfiguration
 from prefect_soda_core.sodacl_check import SodaCLCheck
 from prefect_soda_core.tasks import soda_scan_execute
@@ -57,7 +58,7 @@ def run_soda_scan():
         checks=soda_check_block,
         variables={"var": "value"},
         scan_results_file=scan_results_file_path,
-        verbose=True
+        verbose=True,
         return_scan_result_file_content=False,
         shell_env={"SNOWFLAKE_PASSWORD": "********"}
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 prefect>=2.0.0
 prefect_shell
 soda-core
+pydantic<2

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -95,3 +95,30 @@ async def test_soda_scan_execute_return_scan_result_file_content_succeed(
     flow_result = await test_flow()
 
     assert flow_result == {"result": "fake"}
+
+
+@mock.patch("prefect_soda_core.tasks.shell_run_command.fn")
+async def test_soda_scan_execute_return_none_logs_succeed(mock_shell_run_command_fn):
+    mock_shell_run_command_fn.return_value = _mock_shell_run_command_fn()
+    mock_shell_run_command_fn.side_effect = RuntimeError(
+        "Command failed with exit code 2:"
+    )
+
+    @flow(name="soda_scan_execute_return_none_logs_succeed")
+    async def test_flow():
+        result = await soda_scan_execute(
+            data_source_name="test",
+            configuration=SodaConfiguration(
+                configuration_yaml_path="/path/to/config.yaml",
+                configuration_yaml_str=None,
+            ),
+            checks=SodaCLCheck(
+                sodacl_yaml_path="/path/to/checks.yaml", sodacl_yaml_str=None
+            ),
+            variables=None,
+        )
+        return result
+
+    flow_result = await test_flow()
+
+    assert flow_result == []


### PR DESCRIPTION
Fixed README example  and pinned `pydantic<2` (thanks @zzstoatzz for the hints!)
This should fix #31 
